### PR TITLE
Publish directory and recursive settings unexpected behavior

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,15 @@
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "daily"
-  - package-ecosystem: "docker"
-    directory: "/"
+      interval: 'daily'
+  - package-ecosystem: 'docker'
+    directory: '/'
     schedule:
-      interval: "daily"
-  - package-ecosystem: "npm"
-    directory: "/"
+      interval: 'daily'
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "daily"
+      interval: 'daily'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,32 +1,32 @@
 ---
 version: 1
 labels:
-  - label: "small"
+  - label: 'small'
     size-below: 10
-  - label: "medium"
+  - label: 'medium'
     size-above: 9
     size-below: 200
-  - label: "large"
+  - label: 'large'
     size-above: 200
-  - label: "documentation"
+  - label: 'documentation'
     files:
-      - ".+.md"
-  - label: "config"
+      - '.+.md'
+  - label: 'config'
     files:
-      - ".github"
-      - ".autorc"
-      - ".eslintrc"
-      - ".eslintignore"
-      - ".prettierrc"
-      - ".prettierignore"
-      - ".all-contributorsrc"
-      - "environments"
-      - ".gitignore"
-      - "Dockerfile"
-      - "docker-compose.yml"
-      - "package.json"
-      - ".dockerignore"
-      - ".gitignore"
-  - label: "code"
+      - '.github'
+      - '.autorc'
+      - '.eslintrc'
+      - '.eslintignore'
+      - '.prettierrc'
+      - '.prettierignore'
+      - '.all-contributorsrc'
+      - 'environments'
+      - '.gitignore'
+      - 'Dockerfile'
+      - 'docker-compose.yml'
+      - 'package.json'
+      - '.dockerignore'
+      - '.gitignore'
+  - label: 'code'
     files:
-      - "src"
+      - 'src'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,6 +21,6 @@ jobs:
     steps:
       - uses: ejhayes/labeler@master
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:
-          action_asset_url: "https://github.com/ejhayes/labeler/releases/latest/download/action.tar.gz"
+          action_asset_url: 'https://github.com/ejhayes/labeler/releases/latest/download/action.tar.gz'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -151,6 +151,8 @@ jobs:
           HELM_PLUGIN_PUBLISH_REPOSITORY: local
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          mkdir -p test1/d0/d1
+          node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: true}).then((res) => console.log(res))"
           ls -l test-e2e
           npm run test:e2e || (cd test-e2e && ls -l publish && tree publish)
           cd test-e2e

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches:
-      - '!next'
+      - '!main'
 
 concurrency:
   group: ${{ github.head_ref }}-pr

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,84 +26,84 @@ jobs:
       - if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
-  lint:
-    runs-on: ubuntu-latest
-    needs: [init]
-    permissions: write-all
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-      - uses: actions/cache@v3
-        with:
-          path: ./node_modules
-          key: modules-${{ hashFiles('package-lock.json') }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-      - uses: fossas/fossa-action@main
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-      - uses: wearerequired/lint-action@v2
-        with:
-          eslint: true
-          eslint_extensions: ts
-          prettier: true
-          prettier_extensions: ts,json,js,yml
-          auto_fix: true
-          commit_message: 'chore(lint): Fix code style issues with ${linter}'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_email: 'lint-action@github.com'
-
-  build:
-    runs-on: ubuntu-latest
-    needs: [init]
-    permissions: write-all
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prepare repository
-        run: git fetch --unshallow --tags
-      - uses: actions/cache@v3
-        with:
-          path: ./node_modules
-          key: modules-${{ hashFiles('package-lock.json') }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-      - run: npm run ci:build
-      - env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx auto shipit -d
-
-  test:
-    runs-on: ubuntu-latest
-    needs: [init]
-    timeout-minutes: 3
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prepare repository
-        run: git fetch --unshallow --tags
-      - uses: actions/cache@v3
-        with:
-          path: ./node_modules
-          key: modules-${{ hashFiles('package-lock.json') }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-      - if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: paambaati/codeclimate-action@v5.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          coverageLocations: coverage/lcov.info:lcov
-          coverageCommand: npm run ci:test
-      - if: ${{ github.actor == 'dependabot[bot]' }}
-        run: npm run ci:test
+#  lint:
+#    runs-on: ubuntu-latest
+#    needs: [init]
+#    permissions: write-all
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          token: ${{ secrets.GH_TOKEN }}
+#      - uses: actions/cache@v3
+#        with:
+#          path: ./node_modules
+#          key: modules-${{ hashFiles('package-lock.json') }}
+#      - uses: actions/setup-node@v3
+#        with:
+#          node-version: '18'
+#      - uses: fossas/fossa-action@main
+#        with:
+#          api-key: ${{ secrets.FOSSA_API_KEY }}
+#      - uses: wearerequired/lint-action@v2
+#        with:
+#          eslint: true
+#          eslint_extensions: ts
+#          prettier: true
+#          prettier_extensions: ts,json,js,yml
+#          auto_fix: true
+#          commit_message: 'chore(lint): Fix code style issues with ${linter}'
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          git_email: 'lint-action@github.com'
+#
+#  build:
+#    runs-on: ubuntu-latest
+#    needs: [init]
+#    permissions: write-all
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Prepare repository
+#        run: git fetch --unshallow --tags
+#      - uses: actions/cache@v3
+#        with:
+#          path: ./node_modules
+#          key: modules-${{ hashFiles('package-lock.json') }}
+#      - uses: actions/setup-node@v3
+#        with:
+#          node-version: '18'
+#      - run: npm run ci:build
+#      - env:
+#          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: npx auto shipit -d
+#
+#  test:
+#    runs-on: ubuntu-latest
+#    needs: [init]
+#    timeout-minutes: 3
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Prepare repository
+#        run: git fetch --unshallow --tags
+#      - uses: actions/cache@v3
+#        with:
+#          path: ./node_modules
+#          key: modules-${{ hashFiles('package-lock.json') }}
+#      - uses: actions/setup-node@v3
+#        with:
+#          node-version: '18'
+#      - if: ${{ github.actor != 'dependabot[bot]' }}
+#        uses: paambaati/codeclimate-action@v5.0.0
+#        env:
+#          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        with:
+#          coverageLocations: coverage/lcov.info:lcov
+#          coverageCommand: npm run ci:test
+#      - if: ${{ github.actor == 'dependabot[bot]' }}
+#        run: npm run ci:test
 
   test-e2e:
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [init]
     timeout-minutes: 3
     permissions: write-all
     env:
@@ -144,6 +144,13 @@ jobs:
         run: helm plugin install https://github.com/chartmuseum/helm-push
       - name: Add Chartmuseum repo
         run: helm repo add local $CHARTMUSEUM_BASE_URL
+      - run: |
+          ls -l 
+          npm run test:e2e
+          ls -l publish
+          tree publish
+          npm run ci:test:e2e
+
       - env:
           HELM_PLUGIN_ENABLE_CANARY: true
           HELM_PLUGIN_PUSH: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,8 +3,8 @@ name: Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    branches:
-      - '!main'
+    branches-ignore:
+      - main
 
 concurrency:
   group: ${{ github.head_ref }}-pr

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -153,6 +153,7 @@ jobs:
         run: |
           mkdir -p test1/d0/d1
           node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: true}).then((res) => console.log(res))"
+          node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: false}).then((res) => console.log(res))"
           ls -l test-e2e
           npm run test:e2e || (cd test-e2e && ls -l publish && tree publish)
           cd test-e2e

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -151,10 +151,12 @@ jobs:
           HELM_PLUGIN_PUBLISH_REPOSITORY: local
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ls -l 
-          npm run test:e2e || (ls -l publish && tree publish)
+          ls -l test-e2e
+          npm run test:e2e || (cd test-e2e && ls -l publish && tree publish)
+          cd test-e2e
           ls -l publish
           tree publish
+          cd ..
           npm run ci:build
           npm run test:e2e
       - env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -151,6 +151,7 @@ jobs:
           HELM_PLUGIN_PUBLISH_REPOSITORY: local
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          node -v
           mkdir -p test1/d0/d1
           node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: true}).then((res) => console.log(res))"
           node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: false}).then((res) => console.log(res))"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
           key: modules-${{ hashFiles('package-lock.json') }}
       - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '18'
       - if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
@@ -40,7 +40,7 @@ jobs:
           key: modules-${{ hashFiles('package-lock.json') }}
       - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '18'
       - uses: fossas/fossa-action@main
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
@@ -51,9 +51,9 @@ jobs:
           prettier: true
           prettier_extensions: ts,json,js,yml
           auto_fix: true
-          commit_message: "chore(lint): Fix code style issues with ${linter}"
+          commit_message: 'chore(lint): Fix code style issues with ${linter}'
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_email: "lint-action@github.com"
+          git_email: 'lint-action@github.com'
 
   build:
     runs-on: ubuntu-latest
@@ -69,7 +69,7 @@ jobs:
           key: modules-${{ hashFiles('package-lock.json') }}
       - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '18'
       - run: npm run ci:build
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
           key: modules-${{ hashFiles('package-lock.json') }}
       - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '18'
       - if: ${{ github.actor != 'dependabot[bot]' }}
         uses: paambaati/codeclimate-action@v5.0.0
         env:
@@ -118,8 +118,8 @@ jobs:
           - 8080:8080
         env:
           DEBUG: 1
-          STORAGE: "local"
-          STORAGE_LOCAL_ROOTDIR: "/tmp/charts"
+          STORAGE: 'local'
+          STORAGE_LOCAL_ROOTDIR: '/tmp/charts'
           PORT: 8080
     steps:
       - uses: actions/checkout@v4
@@ -131,7 +131,7 @@ jobs:
           key: modules-${{ hashFiles('package-lock.json') }}
       - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '18'
       # e2e dependencies
       - name: Setup Helm
         uses: azure/setup-helm@v3
@@ -147,7 +147,7 @@ jobs:
       - env:
           HELM_PLUGIN_ENABLE_CANARY: true
           HELM_PLUGIN_PUSH: true
-          HELM_PLUGIN_REPOSITORY: "@local"
+          HELM_PLUGIN_REPOSITORY: '@local'
           HELM_PLUGIN_PUBLISH_REPOSITORY: local
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run ci:test:e2e

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.head_ref }}-pr
   cancel-in-progress: true
 
+env:
+  NODE_VERSION: '18'
+
 jobs:
   init:
     runs-on: ubuntu-latest
@@ -22,84 +25,84 @@ jobs:
           key: modules-${{ hashFiles('package-lock.json') }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       - if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
-#  lint:
-#    runs-on: ubuntu-latest
-#    needs: [init]
-#    permissions: write-all
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          token: ${{ secrets.GH_TOKEN }}
-#      - uses: actions/cache@v3
-#        with:
-#          path: ./node_modules
-#          key: modules-${{ hashFiles('package-lock.json') }}
-#      - uses: actions/setup-node@v3
-#        with:
-#          node-version: '18'
-#      - uses: fossas/fossa-action@main
-#        with:
-#          api-key: ${{ secrets.FOSSA_API_KEY }}
-#      - uses: wearerequired/lint-action@v2
-#        with:
-#          eslint: true
-#          eslint_extensions: ts
-#          prettier: true
-#          prettier_extensions: ts,json,js,yml
-#          auto_fix: true
-#          commit_message: 'chore(lint): Fix code style issues with ${linter}'
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          git_email: 'lint-action@github.com'
-#
-#  build:
-#    runs-on: ubuntu-latest
-#    needs: [init]
-#    permissions: write-all
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Prepare repository
-#        run: git fetch --unshallow --tags
-#      - uses: actions/cache@v3
-#        with:
-#          path: ./node_modules
-#          key: modules-${{ hashFiles('package-lock.json') }}
-#      - uses: actions/setup-node@v3
-#        with:
-#          node-version: '18'
-#      - run: npm run ci:build
-#      - env:
-#          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: npx auto shipit -d
-#
-#  test:
-#    runs-on: ubuntu-latest
-#    needs: [init]
-#    timeout-minutes: 3
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Prepare repository
-#        run: git fetch --unshallow --tags
-#      - uses: actions/cache@v3
-#        with:
-#          path: ./node_modules
-#          key: modules-${{ hashFiles('package-lock.json') }}
-#      - uses: actions/setup-node@v3
-#        with:
-#          node-version: '18'
-#      - if: ${{ github.actor != 'dependabot[bot]' }}
-#        uses: paambaati/codeclimate-action@v5.0.0
-#        env:
-#          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        with:
-#          coverageLocations: coverage/lcov.info:lcov
-#          coverageCommand: npm run ci:test
-#      - if: ${{ github.actor == 'dependabot[bot]' }}
-#        run: npm run ci:test
+  lint:
+    runs-on: ubuntu-latest
+    needs: [init]
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+      - uses: actions/cache@v3
+        with:
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: fossas/fossa-action@main
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+      - uses: wearerequired/lint-action@v2
+        with:
+          eslint: true
+          eslint_extensions: ts
+          prettier: true
+          prettier_extensions: ts,json,js,yml
+          auto_fix: true
+          commit_message: 'chore(lint): Fix code style issues with ${linter}'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          git_email: 'lint-action@github.com'
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [init]
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare repository
+        run: git fetch --unshallow --tags
+      - uses: actions/cache@v3
+        with:
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm run ci:build
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx auto shipit -d
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [init]
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare repository
+        run: git fetch --unshallow --tags
+      - uses: actions/cache@v3
+        with:
+          path: ./node_modules
+          key: modules-${{ hashFiles('package-lock.json') }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: paambaati/codeclimate-action@v5.0.0
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          coverageLocations: coverage/lcov.info:lcov
+          coverageCommand: npm run ci:test
+      - if: ${{ github.actor == 'dependabot[bot]' }}
+        run: npm run ci:test
 
   test-e2e:
     runs-on: ubuntu-latest
@@ -131,7 +134,7 @@ jobs:
           key: modules-${{ hashFiles('package-lock.json') }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       # e2e dependencies
       - name: Setup Helm
         uses: azure/setup-helm@v3
@@ -144,25 +147,6 @@ jobs:
         run: helm plugin install https://github.com/chartmuseum/helm-push
       - name: Add Chartmuseum repo
         run: helm repo add local $CHARTMUSEUM_BASE_URL
-      - env:
-          HELM_PLUGIN_ENABLE_CANARY: true
-          HELM_PLUGIN_PUSH: true
-          HELM_PLUGIN_REPOSITORY: '@local'
-          HELM_PLUGIN_PUBLISH_REPOSITORY: local
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          node -v
-          mkdir -p test1/d0/d1
-          node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: true}).then((res) => console.log(res))"
-          node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: false}).then((res) => console.log(res))"
-          ls -l test-e2e
-          npm run test:e2e || (cd test-e2e && ls -l publish && tree publish)
-          cd test-e2e
-          ls -l publish
-          tree publish
-          cd ..
-          npm run ci:build
-          npm run test:e2e
       - env:
           HELM_PLUGIN_ENABLE_CANARY: true
           HELM_PLUGIN_PUSH: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -144,13 +144,19 @@ jobs:
         run: helm plugin install https://github.com/chartmuseum/helm-push
       - name: Add Chartmuseum repo
         run: helm repo add local $CHARTMUSEUM_BASE_URL
-      - run: |
+      - env:
+          HELM_PLUGIN_ENABLE_CANARY: true
+          HELM_PLUGIN_PUSH: true
+          HELM_PLUGIN_REPOSITORY: '@local'
+          HELM_PLUGIN_PUBLISH_REPOSITORY: local
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           ls -l 
-          npm run test:e2e
+          npm run test:e2e || (ls -l publish && tree publish)
           ls -l publish
           tree publish
-          npm run ci:test:e2e
-
+          npm run ci:build
+          npm run test:e2e
       - env:
           HELM_PLUGIN_ENABLE_CANARY: true
           HELM_PLUGIN_PUSH: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
       - uses: oleksiyrudenko/gha-git-credentials@v2.1
         with:
-          token: "${{ secrets.GH_TOKEN }}"
+          token: '${{ secrets.GH_TOKEN }}'
       - name: Prepare repository
         run: git fetch --unshallow --tags
       - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '18'
       - name: Cache node modules
         uses: actions/cache@v3
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 
 permissions: write-all
 
+env:
+  NODE_VERSION: '18'
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -24,7 +27,7 @@ jobs:
         run: git fetch --unshallow --tags
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
       - name: Cache node modules
         uses: actions/cache@v3
         env:

--- a/.github/workflows/required_labels.yml
+++ b/.github/workflows/required_labels.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "major,minor,patch,skip-release,internal"
+          labels: 'major,minor,patch,skip-release,internal'

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -29,4 +29,4 @@ jobs:
         uses: ejhayes/tdg-github-action@master
         with:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTION_ASSET_URL: "https://github.com/ejhayes/tdg-github-action/releases/latest/download/action.tar.gz"
+          ACTION_ASSET_URL: 'https://github.com/ejhayes/tdg-github-action/releases/latest/download/action.tar.gz'

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": false,
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # auto-plugin-helm-chartmuseum
+
 [![npm version](https://badge.fury.io/js/auto-plugin-helm-chartmuseum.svg)](https://badge.fury.io/js/auto-plugin-helm-chartmuseum) [![Maintainability](https://api.codeclimate.com/v1/badges/0786ebf1133fdadab59d/maintainability)](https://codeclimate.com/github/ejhayes/auto-plugin-helm-chartmuseum/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/0786ebf1133fdadab59d/test_coverage)](https://codeclimate.com/github/ejhayes/auto-plugin-helm-chartmuseum/test_coverage) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fejhayes%2Fauto-plugin-helm-chartmuseum.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fejhayes%2Fauto-plugin-helm-chartmuseum?ref=badge_shield) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Auto plugin for helm charts! This plugin can do the following:
 
@@ -40,6 +41,7 @@ To use in your projects, add this to you `.autorc` file under `plugins` section:
 ```
 
 ### github actions
+
 You can use this with GitHub actions as follows:
 
 ```yaml
@@ -57,7 +59,7 @@ You can use this with GitHub actions as follows:
 - env:
     HELM_PLUGIN_ENABLE_CANARY: true
     HELM_PLUGIN_PUSH: true
-    HELM_PLUGIN_REPOSITORY: "@local"
+    HELM_PLUGIN_REPOSITORY: '@local'
     HELM_PLUGIN_PUBLISH_REPOSITORY: local
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   run: npx auto shipit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
-version: "3"
+version: '3'
 
 services:
   chartmuseum:
     image: ghcr.io/helm/chartmuseum:v0.16.0
     ports:
-      - "8080:8080"
+      - '8080:8080'
     environment:
       DEBUG: 1
-      STORAGE: "local"
-      STORAGE_LOCAL_ROOTDIR: "/tmp/charts"
+      STORAGE: 'local'
+      STORAGE_LOCAL_ROOTDIR: '/tmp/charts'
     #volumes:
     #  - './charts:/charts'

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 // eslint-disable-next-line no-undef
 module.exports = {
   collectCoverage: true,
-  coverageReporters: ["lcov", "text"],
-  preset: "ts-jest",
-  testEnvironment: "node",
-};
+  coverageReporters: ['lcov', 'text'],
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ci:test": "npm run test -- --coverage",
     "ci:test:e2e": "npm run test:e2e",
     "lint": "eslint .",
-    "format": "",
+    "format": "prettier --write .",
     "build": "rimraf dist && tsc -p tsconfig.build.json",
     "services:start": "docker compose up -d chartmuseum",
     "services:stop": "docker compose stop",

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -99,7 +99,10 @@ export class Helm {
     for (const chartDir of chartDirs) {
       const chartPath = join(destPath, chartDir)
       if (opts.replaceVersionToken && this.options.versionToken) {
-        for (const file of await this.findMatchingChartFiles(chartPath)) {
+        this.logger.log(`Using: ${chartPath}`)
+        const files = await this.findMatchingChartFiles(chartPath)
+        this.logger.log(files)
+        for (const file of files) {
           await this.inlineReplace(join(chartPath, file), (content) => {
             return content.replace(
               new RegExp(this.options.versionToken, 'ig'),

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -181,8 +181,26 @@ export class Helm {
   async getChartDirs(path: string, recursive = false): Promise<string[]> {
     if (recursive) {
       return (
+        /**
+         * Behavior of readdir differs with recursive option set to true.
+         * - On mac/ubuntu environments setting this value to true has the same
+         *   behavior (1 level deep)
+         *   $ mkdir -p test1/d0/d1
+         *   $ node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: true}).then((res) => console.log(res))"
+         *   [ 'd0' ]
+         * 
+         * - On github actions (using ubuntu-latest) setting this value to true
+         *   returns all nested directories (more than 1 level deep)
+         *   $ mkdir -p test1/d0/d1
+         *   $ node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: true}).then((res) => console.log(res))"
+         *   [ 'd0', 'd0/d1' ]
+         * 
+         * This could possibly be related to https://github.com/nodejs/node/issues/49243
+         * but regardless should not be set to any other value than false until we can
+         * guarantee behavior between environments
+         */
         await readdir(path, {
-          recursive: true,
+          recursive: false,
           withFileTypes: true,
         })
       )

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -24,7 +24,7 @@ export class Helm {
 
   constructor(
     private readonly logger: ILogger,
-    options: Partial<HelmOptions>,
+    options: Partial<HelmOptions>
   ) {
     this.options = {
       useHelmDocs:
@@ -72,7 +72,7 @@ export class Helm {
     version: string,
     srcPath: string,
     destPath: string,
-    _opts: Partial<PrepOptions> = {},
+    _opts: Partial<PrepOptions> = {}
   ) {
     const opts: PrepOptions = {
       recursive: true,
@@ -96,7 +96,7 @@ export class Helm {
           await this.inlineReplace(join(chartPath, file), (content) => {
             return content.replace(
               new RegExp(this.options.versionToken, "ig"),
-              version,
+              version
             );
           });
         }
@@ -142,7 +142,7 @@ export class Helm {
     srcPath: string,
     destPath: string,
     version: string,
-    opts: PrepOptions,
+    opts: PrepOptions
   ) {
     this.logger.log.info(`Creating chart: ${srcPath} version ${version}`);
 
@@ -172,13 +172,17 @@ export class Helm {
     if (recursive) {
       // Recursive read doesn't give the complete path in the name
       return (
-        await readdir(path, {
-          recursive: true,
-          withFileTypes: true,
-        })
-      )
-        .filter((i) => i.isDirectory())
-        .map((i) => join(i.path, i.name).replace(`${path}/`, ''));
+        (
+          await readdir(path, {
+            recursive: true,
+            withFileTypes: true,
+          })
+        )
+          .filter((i) => i.isDirectory())
+          // Ignore templates and test directories here. The Plugin tries to builds them as full charts.
+          .filter((i) => i.name !== "templates" && i.name !== "test")
+          .map((i) => join(i.path, i.name).replace(`${path}/`, ""))
+      );
     }
 
     return path;

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -1,26 +1,26 @@
-import { readdir, rm, mkdir, cp, readFile, writeFile } from "fs/promises";
-import { execPromise, ILogger } from "@auto-it/core";
-import { join } from "path";
+import { readdir, rm, mkdir, cp, readFile, writeFile } from 'fs/promises'
+import { execPromise, ILogger } from '@auto-it/core'
+import { join } from 'path'
 
 enum TOOLS {
-  HELM = "helm",
-  HELM_DOCS = "helm-docs",
+  HELM = 'helm',
+  HELM_DOCS = 'helm-docs',
 }
 
 interface HelmOptions {
-  versionToken: string;
-  useHelmDocs: boolean;
+  versionToken: string
+  useHelmDocs: boolean
 }
 
 interface PrepOptions {
-  repository?: string;
-  recursive: boolean;
-  replaceVersionToken: boolean;
-  replaceFileWithRepository: boolean;
+  repository?: string
+  recursive: boolean
+  replaceVersionToken: boolean
+  replaceFileWithRepository: boolean
 }
 
 export class Helm {
-  options: HelmOptions;
+  options: HelmOptions
 
   constructor(
     private readonly logger: ILogger,
@@ -32,19 +32,19 @@ export class Helm {
       versionToken:
         options.versionToken !== undefined
           ? options.versionToken
-          : "0.0.0-local",
-    };
+          : '0.0.0-local',
+    }
   }
 
   async validateDependencies() {
-    this.logger.log.info("Checking for helm...");
-    await execPromise(TOOLS.HELM, ["version"]);
+    this.logger.log.info('Checking for helm...')
+    await execPromise(TOOLS.HELM, ['version'])
 
     if (this.options.useHelmDocs) {
-      this.logger.log.info("Checking for helm-docs...");
-      await execPromise(TOOLS.HELM_DOCS, ["--version"]);
+      this.logger.log.info('Checking for helm-docs...')
+      await execPromise(TOOLS.HELM_DOCS, ['--version'])
     } else {
-      this.logger.log.info("Skipping check for helm-docs");
+      this.logger.log.info('Skipping check for helm-docs')
     }
   }
 
@@ -55,16 +55,16 @@ export class Helm {
       })
     )
       .filter((i) => i.isFile() && i.name.search(/\.tgz$/) >= 0)
-      .map((i) => join(path, i.name));
+      .map((i) => join(path, i.name))
 
     for (const chart of chartsToPublish) {
-      this.logger.log.info(`Publishing ${chart}`);
+      this.logger.log.info(`Publishing ${chart}`)
       await execPromise(TOOLS.HELM, [
-        "cm-push",
-        ...(forcePush ? ["-f"] : []),
+        'cm-push',
+        ...(forcePush ? ['-f'] : []),
         chart,
         repository,
-      ]);
+      ])
     }
   }
 
@@ -79,63 +79,63 @@ export class Helm {
       replaceFileWithRepository: true,
       replaceVersionToken: true,
       ..._opts,
-    };
-    const chartDirs = await this.getChartDirs(srcPath, opts.recursive);
+    }
+    const chartDirs = await this.getChartDirs(srcPath, opts.recursive)
 
-    await rm(destPath, { recursive: true, force: true });
-    await mkdir(destPath, { recursive: true });
+    await rm(destPath, { recursive: true, force: true })
+    await mkdir(destPath, { recursive: true })
     await cp(srcPath, destPath, {
       recursive: true,
-    });
+    })
 
     // replace all versions with the current version
     for (const chartDir of chartDirs) {
-      const chartPath = join(destPath, chartDir);
+      const chartPath = join(destPath, chartDir)
       if (opts.replaceVersionToken && this.options.versionToken) {
         for (const file of await this.findMatchingChartFiles(chartPath)) {
           await this.inlineReplace(join(chartPath, file), (content) => {
             return content.replace(
-              new RegExp(this.options.versionToken, "ig"),
+              new RegExp(this.options.versionToken, 'ig'),
               version,
-            );
-          });
+            )
+          })
         }
       }
     }
 
     if (this.options.useHelmDocs) {
-      this.logger.log.info("Updating documentation");
-      await execPromise(TOOLS.HELM_DOCS, ["-u", "publish", "-s", "alphanum"]);
+      this.logger.log.info('Updating documentation')
+      await execPromise(TOOLS.HELM_DOCS, ['-u', 'publish', '-s', 'alphanum'])
     } else {
-      this.logger.log.info("Skipping documentation generation");
+      this.logger.log.info('Skipping documentation generation')
     }
 
     for (const chartDir of chartDirs) {
-      await this.prepChart(join(destPath, chartDir), destPath, version, opts);
+      await this.prepChart(join(destPath, chartDir), destPath, version, opts)
     }
 
     for (const chartDir of chartDirs) {
       await rm(join(destPath, chartDir), {
         recursive: true,
         force: true,
-      });
+      })
     }
   }
 
   async inlineReplace(path: string, replacers: (contents: string) => string) {
-    this.logger.log.debug(`Inline replacement for ${path}`);
+    this.logger.log.debug(`Inline replacement for ${path}`)
 
-    const contents = replacers((await readFile(path)).toString());
+    const contents = replacers((await readFile(path)).toString())
 
-    return await writeFile(path, contents);
+    return await writeFile(path, contents)
   }
 
   async findMatchingChartFiles(chartPath: string) {
-    const MATCHER = /(readme\.md)|(chart\.ya?ml)|(chart\.lock)/i;
+    const MATCHER = /(readme\.md)|(chart\.ya?ml)|(chart\.lock)/i
     return (await readdir(chartPath, { withFileTypes: true }))
       .filter((i) => i.isFile())
       .map((i) => i.name)
-      .filter((i) => i.search(MATCHER) >= 0);
+      .filter((i) => i.search(MATCHER) >= 0)
   }
 
   async prepChart(
@@ -144,28 +144,28 @@ export class Helm {
     version: string,
     opts: PrepOptions,
   ) {
-    this.logger.log.info(`Creating chart: ${srcPath} version ${version}`);
+    this.logger.log.info(`Creating chart: ${srcPath} version ${version}`)
 
     // remove charts dir external dependencies
-    await rm(join(srcPath, "charts", "*.tgz"), {
+    await rm(join(srcPath, 'charts', '*.tgz'), {
       recursive: true,
       force: true,
-    });
+    })
 
     // update dependencies
-    await execPromise(TOOLS.HELM, ["dep", "up", srcPath]);
+    await execPromise(TOOLS.HELM, ['dep', 'up', srcPath])
 
     // update file references with repo aliases
     if (opts.replaceFileWithRepository && opts.repository) {
       for (const file of await this.findMatchingChartFiles(srcPath)) {
         await this.inlineReplace(join(srcPath, file), (contents) => {
-          return contents.replace(/file:\/\/[^\s]+/g, `'${opts.repository}'`);
-        });
+          return contents.replace(/file:\/\/[^\s]+/g, `'${opts.repository}'`)
+        })
       }
     }
 
     // package the chart
-    await execPromise(TOOLS.HELM, ["package", srcPath, "-d", destPath]);
+    await execPromise(TOOLS.HELM, ['package', srcPath, '-d', destPath])
   }
 
   async getChartDirs(path: string, recursive = false) {
@@ -177,9 +177,9 @@ export class Helm {
         })
       )
         .filter((i) => i.isDirectory())
-        .map((i) => i.name);
+        .map((i) => i.name)
     }
 
-    return path;
+    return path
   }
 }

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -1,26 +1,26 @@
-import { readdir, rm, mkdir, cp, readFile, writeFile } from 'fs/promises'
-import { execPromise, ILogger } from '@auto-it/core'
-import { join } from 'path'
+import { readdir, rm, mkdir, cp, readFile, writeFile } from "fs/promises";
+import { execPromise, ILogger } from "@auto-it/core";
+import { join } from "path";
 
 enum TOOLS {
-  HELM = 'helm',
-  HELM_DOCS = 'helm-docs',
+  HELM = "helm",
+  HELM_DOCS = "helm-docs",
 }
 
 interface HelmOptions {
-  versionToken: string
-  useHelmDocs: boolean
+  versionToken: string;
+  useHelmDocs: boolean;
 }
 
 interface PrepOptions {
-  repository?: string
-  recursive: boolean
-  replaceVersionToken: boolean
-  replaceFileWithRepository: boolean
+  repository?: string;
+  recursive: boolean;
+  replaceVersionToken: boolean;
+  replaceFileWithRepository: boolean;
 }
 
 export class Helm {
-  options: HelmOptions
+  options: HelmOptions;
 
   constructor(
     private readonly logger: ILogger,
@@ -32,19 +32,19 @@ export class Helm {
       versionToken:
         options.versionToken !== undefined
           ? options.versionToken
-          : '0.0.0-local',
-    }
+          : "0.0.0-local",
+    };
   }
 
   async validateDependencies() {
-    this.logger.log.info('Checking for helm...')
-    await execPromise(TOOLS.HELM, ['version'])
+    this.logger.log.info("Checking for helm...");
+    await execPromise(TOOLS.HELM, ["version"]);
 
     if (this.options.useHelmDocs) {
-      this.logger.log.info('Checking for helm-docs...')
-      await execPromise(TOOLS.HELM_DOCS, ['--version'])
+      this.logger.log.info("Checking for helm-docs...");
+      await execPromise(TOOLS.HELM_DOCS, ["--version"]);
     } else {
-      this.logger.log.info('Skipping check for helm-docs')
+      this.logger.log.info("Skipping check for helm-docs");
     }
   }
 
@@ -55,16 +55,16 @@ export class Helm {
       })
     )
       .filter((i) => i.isFile() && i.name.search(/\.tgz$/) >= 0)
-      .map((i) => join(path, i.name))
+      .map((i) => join(path, i.name));
 
     for (const chart of chartsToPublish) {
-      this.logger.log.info(`Publishing ${chart}`)
+      this.logger.log.info(`Publishing ${chart}`);
       await execPromise(TOOLS.HELM, [
-        'cm-push',
-        ...(forcePush ? ['-f'] : []),
+        "cm-push",
+        ...(forcePush ? ["-f"] : []),
         chart,
         repository,
-      ])
+      ]);
     }
   }
 
@@ -79,63 +79,63 @@ export class Helm {
       replaceFileWithRepository: true,
       replaceVersionToken: true,
       ..._opts,
-    }
-    const chartDirs = await this.getChartDirs(srcPath, opts.recursive)
+    };
+    const chartDirs = await this.getChartDirs(srcPath, opts.recursive);
 
-    await rm(destPath, { recursive: true, force: true })
-    await mkdir(destPath, { recursive: true })
+    await rm(destPath, { recursive: true, force: true });
+    await mkdir(destPath, { recursive: true });
     await cp(srcPath, destPath, {
       recursive: true,
-    })
+    });
 
     // replace all versions with the current version
     for (const chartDir of chartDirs) {
-      const chartPath = join(destPath, chartDir)
+      const chartPath = join(destPath, chartDir);
       if (opts.replaceVersionToken && this.options.versionToken) {
         for (const file of await this.findMatchingChartFiles(chartPath)) {
           await this.inlineReplace(join(chartPath, file), (content) => {
             return content.replace(
-              new RegExp(this.options.versionToken, 'ig'),
+              new RegExp(this.options.versionToken, "ig"),
               version,
-            )
-          })
+            );
+          });
         }
       }
     }
 
     if (this.options.useHelmDocs) {
-      this.logger.log.info('Updating documentation')
-      await execPromise(TOOLS.HELM_DOCS, ['-u', 'publish', '-s', 'alphanum'])
+      this.logger.log.info("Updating documentation");
+      await execPromise(TOOLS.HELM_DOCS, ["-u", "publish", "-s", "alphanum"]);
     } else {
-      this.logger.log.info('Skipping documentation generation')
+      this.logger.log.info("Skipping documentation generation");
     }
 
     for (const chartDir of chartDirs) {
-      await this.prepChart(join(destPath, chartDir), destPath, version, opts)
+      await this.prepChart(join(destPath, chartDir), destPath, version, opts);
     }
 
     for (const chartDir of chartDirs) {
       await rm(join(destPath, chartDir), {
         recursive: true,
         force: true,
-      })
+      });
     }
   }
 
   async inlineReplace(path: string, replacers: (contents: string) => string) {
-    this.logger.log.debug(`Inline replacement for ${path}`)
+    this.logger.log.debug(`Inline replacement for ${path}`);
 
-    const contents = replacers((await readFile(path)).toString())
+    const contents = replacers((await readFile(path)).toString());
 
-    return await writeFile(path, contents)
+    return await writeFile(path, contents);
   }
 
   async findMatchingChartFiles(chartPath: string) {
-    const MATCHER = /(readme\.md)|(chart\.ya?ml)|(chart\.lock)/i
+    const MATCHER = /(readme\.md)|(chart\.ya?ml)|(chart\.lock)/i;
     return (await readdir(chartPath, { withFileTypes: true }))
       .filter((i) => i.isFile())
       .map((i) => i.name)
-      .filter((i) => i.search(MATCHER) >= 0)
+      .filter((i) => i.search(MATCHER) >= 0);
   }
 
   async prepChart(
@@ -144,47 +144,42 @@ export class Helm {
     version: string,
     opts: PrepOptions,
   ) {
-    this.logger.log.info(`Creating chart: ${srcPath} version ${version}`)
+    this.logger.log.info(`Creating chart: ${srcPath} version ${version}`);
 
     // remove charts dir external dependencies
-    await rm(join(srcPath, 'charts', '*.tgz'), {
+    await rm(join(srcPath, "charts", "*.tgz"), {
       recursive: true,
       force: true,
-    })
+    });
 
     // update dependencies
-    await execPromise(TOOLS.HELM, ['dep', 'up', srcPath])
+    await execPromise(TOOLS.HELM, ["dep", "up", srcPath]);
 
     // update file references with repo aliases
     if (opts.replaceFileWithRepository && opts.repository) {
       for (const file of await this.findMatchingChartFiles(srcPath)) {
         await this.inlineReplace(join(srcPath, file), (contents) => {
-          return contents.replace(/file:\/\/[^\s]+/g, `'${opts.repository}'`)
-        })
+          return contents.replace(/file:\/\/[^\s]+/g, `'${opts.repository}'`);
+        });
       }
     }
 
     // package the chart
-    await execPromise(TOOLS.HELM, ['package', srcPath, '-d', destPath])
+    await execPromise(TOOLS.HELM, ["package", srcPath, "-d", destPath]);
   }
 
   async getChartDirs(path: string, recursive = false) {
     if (recursive) {
-      // Recursive read doesn't give the complete path in the name
       return (
-        (
-          await readdir(path, {
-            recursive: true,
-            withFileTypes: true,
-          })
-        )
-          .filter((i) => i.isDirectory())
-          // Ignore templates and test directories here. The Plugin tries to builds them as full charts.
-          .filter((i) => i.name !== 'templates' && i.name !== 'test')
-          .map((i) => join(i.path, i.name).replace(`${path}/`, ''))
+        await readdir(path, {
+          recursive: true,
+          withFileTypes: true,
+        })
       )
+        .filter((i) => i.isDirectory())
+        .map((i) => i.name);
     }
 
-    return path
+    return path;
   }
 }

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -1,30 +1,30 @@
-import { readdir, rm, mkdir, cp, readFile, writeFile } from "fs/promises";
-import { execPromise, ILogger } from "@auto-it/core";
-import { join } from "path";
+import { readdir, rm, mkdir, cp, readFile, writeFile } from 'fs/promises'
+import { execPromise, ILogger } from '@auto-it/core'
+import { join } from 'path'
 
 enum TOOLS {
-  HELM = "helm",
-  HELM_DOCS = "helm-docs",
+  HELM = 'helm',
+  HELM_DOCS = 'helm-docs',
 }
 
 interface HelmOptions {
-  versionToken: string;
-  useHelmDocs: boolean;
+  versionToken: string
+  useHelmDocs: boolean
 }
 
 interface PrepOptions {
-  repository?: string;
-  recursive: boolean;
-  replaceVersionToken: boolean;
-  replaceFileWithRepository: boolean;
+  repository?: string
+  recursive: boolean
+  replaceVersionToken: boolean
+  replaceFileWithRepository: boolean
 }
 
 export class Helm {
-  options: HelmOptions;
+  options: HelmOptions
 
   constructor(
     private readonly logger: ILogger,
-    options: Partial<HelmOptions>
+    options: Partial<HelmOptions>,
   ) {
     this.options = {
       useHelmDocs:
@@ -32,19 +32,19 @@ export class Helm {
       versionToken:
         options.versionToken !== undefined
           ? options.versionToken
-          : "0.0.0-local",
-    };
+          : '0.0.0-local',
+    }
   }
 
   async validateDependencies() {
-    this.logger.log.info("Checking for helm...");
-    await execPromise(TOOLS.HELM, ["version"]);
+    this.logger.log.info('Checking for helm...')
+    await execPromise(TOOLS.HELM, ['version'])
 
     if (this.options.useHelmDocs) {
-      this.logger.log.info("Checking for helm-docs...");
-      await execPromise(TOOLS.HELM_DOCS, ["--version"]);
+      this.logger.log.info('Checking for helm-docs...')
+      await execPromise(TOOLS.HELM_DOCS, ['--version'])
     } else {
-      this.logger.log.info("Skipping check for helm-docs");
+      this.logger.log.info('Skipping check for helm-docs')
     }
   }
 
@@ -55,16 +55,16 @@ export class Helm {
       })
     )
       .filter((i) => i.isFile() && i.name.search(/\.tgz$/) >= 0)
-      .map((i) => join(path, i.name));
+      .map((i) => join(path, i.name))
 
     for (const chart of chartsToPublish) {
-      this.logger.log.info(`Publishing ${chart}`);
+      this.logger.log.info(`Publishing ${chart}`)
       await execPromise(TOOLS.HELM, [
-        "cm-push",
-        ...(forcePush ? ["-f"] : []),
+        'cm-push',
+        ...(forcePush ? ['-f'] : []),
         chart,
         repository,
-      ]);
+      ])
     }
   }
 
@@ -72,100 +72,100 @@ export class Helm {
     version: string,
     srcPath: string,
     destPath: string,
-    _opts: Partial<PrepOptions> = {}
+    _opts: Partial<PrepOptions> = {},
   ) {
     const opts: PrepOptions = {
       recursive: true,
       replaceFileWithRepository: true,
       replaceVersionToken: true,
       ..._opts,
-    };
-    const chartDirs = await this.getChartDirs(srcPath, opts.recursive);
+    }
+    const chartDirs = await this.getChartDirs(srcPath, opts.recursive)
 
-    await rm(destPath, { recursive: true, force: true });
-    await mkdir(destPath, { recursive: true });
+    await rm(destPath, { recursive: true, force: true })
+    await mkdir(destPath, { recursive: true })
     await cp(srcPath, destPath, {
       recursive: true,
-    });
+    })
 
     // replace all versions with the current version
     for (const chartDir of chartDirs) {
-      const chartPath = join(destPath, chartDir);
+      const chartPath = join(destPath, chartDir)
       if (opts.replaceVersionToken && this.options.versionToken) {
         for (const file of await this.findMatchingChartFiles(chartPath)) {
           await this.inlineReplace(join(chartPath, file), (content) => {
             return content.replace(
-              new RegExp(this.options.versionToken, "ig"),
-              version
-            );
-          });
+              new RegExp(this.options.versionToken, 'ig'),
+              version,
+            )
+          })
         }
       }
     }
 
     if (this.options.useHelmDocs) {
-      this.logger.log.info("Updating documentation");
-      await execPromise(TOOLS.HELM_DOCS, ["-u", "publish", "-s", "alphanum"]);
+      this.logger.log.info('Updating documentation')
+      await execPromise(TOOLS.HELM_DOCS, ['-u', 'publish', '-s', 'alphanum'])
     } else {
-      this.logger.log.info("Skipping documentation generation");
+      this.logger.log.info('Skipping documentation generation')
     }
 
     for (const chartDir of chartDirs) {
-      await this.prepChart(join(destPath, chartDir), destPath, version, opts);
+      await this.prepChart(join(destPath, chartDir), destPath, version, opts)
     }
 
     for (const chartDir of chartDirs) {
       await rm(join(destPath, chartDir), {
         recursive: true,
         force: true,
-      });
+      })
     }
   }
 
   async inlineReplace(path: string, replacers: (contents: string) => string) {
-    this.logger.log.debug(`Inline replacement for ${path}`);
+    this.logger.log.debug(`Inline replacement for ${path}`)
 
-    const contents = replacers((await readFile(path)).toString());
+    const contents = replacers((await readFile(path)).toString())
 
-    return await writeFile(path, contents);
+    return await writeFile(path, contents)
   }
 
   async findMatchingChartFiles(chartPath: string) {
-    const MATCHER = /(readme\.md)|(chart\.ya?ml)|(chart\.lock)/i;
+    const MATCHER = /(readme\.md)|(chart\.ya?ml)|(chart\.lock)/i
     return (await readdir(chartPath, { withFileTypes: true }))
       .filter((i) => i.isFile())
       .map((i) => i.name)
-      .filter((i) => i.search(MATCHER) >= 0);
+      .filter((i) => i.search(MATCHER) >= 0)
   }
 
   async prepChart(
     srcPath: string,
     destPath: string,
     version: string,
-    opts: PrepOptions
+    opts: PrepOptions,
   ) {
-    this.logger.log.info(`Creating chart: ${srcPath} version ${version}`);
+    this.logger.log.info(`Creating chart: ${srcPath} version ${version}`)
 
     // remove charts dir external dependencies
-    await rm(join(srcPath, "charts", "*.tgz"), {
+    await rm(join(srcPath, 'charts', '*.tgz'), {
       recursive: true,
       force: true,
-    });
+    })
 
     // update dependencies
-    await execPromise(TOOLS.HELM, ["dep", "up", srcPath]);
+    await execPromise(TOOLS.HELM, ['dep', 'up', srcPath])
 
     // update file references with repo aliases
     if (opts.replaceFileWithRepository && opts.repository) {
       for (const file of await this.findMatchingChartFiles(srcPath)) {
         await this.inlineReplace(join(srcPath, file), (contents) => {
-          return contents.replace(/file:\/\/[^\s]+/g, `'${opts.repository}'`);
-        });
+          return contents.replace(/file:\/\/[^\s]+/g, `'${opts.repository}'`)
+        })
       }
     }
 
     // package the chart
-    await execPromise(TOOLS.HELM, ["package", srcPath, "-d", destPath]);
+    await execPromise(TOOLS.HELM, ['package', srcPath, '-d', destPath])
   }
 
   async getChartDirs(path: string, recursive = false) {
@@ -180,11 +180,11 @@ export class Helm {
         )
           .filter((i) => i.isDirectory())
           // Ignore templates and test directories here. The Plugin tries to builds them as full charts.
-          .filter((i) => i.name !== "templates" && i.name !== "test")
-          .map((i) => join(i.path, i.name).replace(`${path}/`, ""))
-      );
+          .filter((i) => i.name !== 'templates' && i.name !== 'test')
+          .map((i) => join(i.path, i.name).replace(`${path}/`, ''))
+      )
     }
 
-    return path;
+    return path
   }
 }

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -80,13 +80,20 @@ export class Helm {
       replaceVersionToken: true,
       ..._opts,
     }
-    const chartDirs = await this.getChartDirs(srcPath, opts.recursive)
 
     await rm(destPath, { recursive: true, force: true })
     await mkdir(destPath, { recursive: true })
+    /**
+     * recursive in this case just means that we want to
+     * copy the full contents of the srcPath over to the
+     * destPath
+     */
     await cp(srcPath, destPath, {
       recursive: true,
     })
+
+    // get list of chartDirs from the publish directory
+    const chartDirs = await this.getChartDirs(destPath, opts.recursive)
 
     // replace all versions with the current version
     for (const chartDir of chartDirs) {
@@ -168,7 +175,7 @@ export class Helm {
     await execPromise(TOOLS.HELM, ['package', srcPath, '-d', destPath])
   }
 
-  async getChartDirs(path: string, recursive = false) {
+  async getChartDirs(path: string, recursive = false): Promise<string[]> {
     if (recursive) {
       return (
         await readdir(path, {
@@ -180,6 +187,6 @@ export class Helm {
         .map((i) => i.name)
     }
 
-    return path
+    return [path]
   }
 }

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -99,9 +99,9 @@ export class Helm {
     for (const chartDir of chartDirs) {
       const chartPath = join(destPath, chartDir)
       if (opts.replaceVersionToken && this.options.versionToken) {
-        this.logger.log(`Using: ${chartPath}`)
+        this.logger.log.info(`Using: ${chartPath}`)
         const files = await this.findMatchingChartFiles(chartPath)
-        this.logger.log(files)
+        this.logger.log.info(files)
         for (const file of files) {
           await this.inlineReplace(join(chartPath, file), (content) => {
             return content.replace(

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -99,9 +99,7 @@ export class Helm {
     for (const chartDir of chartDirs) {
       const chartPath = join(destPath, chartDir)
       if (opts.replaceVersionToken && this.options.versionToken) {
-        this.logger.log.info(`Using: ${chartPath}`)
         const files = await this.findMatchingChartFiles(chartPath)
-        this.logger.log.info(files)
         for (const file of files) {
           await this.inlineReplace(join(chartPath, file), (content) => {
             return content.replace(

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -188,24 +188,26 @@ export class Helm {
          *   $ mkdir -p test1/d0/d1
          *   $ node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: true}).then((res) => console.log(res))"
          *   [ 'd0' ]
-         * 
+         *
          * - On github actions (using ubuntu-latest) setting this value to true
          *   returns all nested directories (more than 1 level deep)
          *   $ mkdir -p test1/d0/d1
          *   $ node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: true}).then((res) => console.log(res))"
          *   [ 'd0', 'd0/d1' ]
-         * 
+         *
          * This could possibly be related to https://github.com/nodejs/node/issues/49243
          * but regardless should not be set to any other value than false until we can
          * guarantee behavior between environments
          */
-        await readdir(path, {
-          recursive: false,
-          withFileTypes: true,
-        })
+        (
+          await readdir(path, {
+            recursive: false,
+            withFileTypes: true,
+          })
+        )
+          .filter((i) => i.isDirectory())
+          .map((i) => i.name)
       )
-        .filter((i) => i.isDirectory())
-        .map((i) => i.name)
     }
 
     return [path]

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,6 @@ export default class HelmPlugin implements IPlugin {
         }
 
         auto.logger.log.info(`Creating canary version: ${canaryVersion}`)
-        auto.logger.log.info(JSON.stringify(this.options))
         await helm.prepCharts(
           canaryVersion,
           this.options.path,

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,6 +193,7 @@ export default class HelmPlugin implements IPlugin {
         }
 
         auto.logger.log.info(`Creating canary version: ${canaryVersion}`)
+        auto.logger.log.info(JSON.stringify(this.options))
         await helm.prepCharts(
           canaryVersion,
           this.options.path,

--- a/test-e2e/test-e2e.spec.ts
+++ b/test-e2e/test-e2e.spec.ts
@@ -1,56 +1,56 @@
-import { RestClient } from "typed-rest-client";
-import { spawn } from "child_process";
+import { RestClient } from 'typed-rest-client'
+import { spawn } from 'child_process'
 
 const CHARTMUSEUM_BASE_URL =
-  process.env.CHARTMUSEUM_BASE_URL || "http://localhost:8080";
+  process.env.CHARTMUSEUM_BASE_URL || 'http://localhost:8080'
 
 interface IChartVersion {
-  name: string;
-  version: string;
+  name: string
+  version: string
 }
 
 interface ICharts {
-  [chartName: string]: IChartVersion[];
+  [chartName: string]: IChartVersion[]
 }
 
 async function runCommand(command: string, args: string[]) {
   return new Promise((resolve, reject) => {
-    const cmd = spawn(command, args);
+    const cmd = spawn(command, args)
 
-    cmd.stdout.on("data", (data) => {
-      console.log(`${data}`);
-    });
+    cmd.stdout.on('data', (data) => {
+      console.log(`${data}`)
+    })
 
-    cmd.stderr.on("data", (data) => {
-      console.error(`${data}`);
-    });
+    cmd.stderr.on('data', (data) => {
+      console.error(`${data}`)
+    })
 
-    cmd.on("close", (code) => {
-      console.log(`child process exited with code ${code}`);
+    cmd.on('close', (code) => {
+      console.log(`child process exited with code ${code}`)
 
       if (code == 0) {
-        resolve(code);
-        return;
+        resolve(code)
+        return
       }
 
-      reject(code);
-    });
-  });
+      reject(code)
+    })
+  })
 }
 
-describe("e2e tests", () => {
+describe('e2e tests', () => {
   const client: RestClient = new RestClient(
-    "jest",
+    'jest',
     `${CHARTMUSEUM_BASE_URL}/api`,
-  );
+  )
 
   async function clearChartmuseum() {
     // remove everything from chartmuseum
-    const res = await client.get<ICharts>("charts");
+    const res = await client.get<ICharts>('charts')
 
     for (const [, versions] of Object.entries(res.result || {})) {
       for (const version of versions) {
-        await client.del(`charts/${version.name}/${version.version}`);
+        await client.del(`charts/${version.name}/${version.version}`)
       }
     }
   }
@@ -61,36 +61,36 @@ describe("e2e tests", () => {
    * runs without error
    */
   beforeAll(async () => {
-    await clearChartmuseum();
-    const charts = await client.get("charts");
-    expect(charts.statusCode).toBe(200);
-    expect(JSON.stringify(charts.result)).toBe("{}");
+    await clearChartmuseum()
+    const charts = await client.get('charts')
+    expect(charts.statusCode).toBe(200)
+    expect(JSON.stringify(charts.result)).toBe('{}')
 
-    const autoReturnCode = await runCommand("npx", [
-      "auto",
-      "canary",
-      "--force",
-    ]);
-    expect(autoReturnCode).toBe(0);
-  }, 40000);
+    const autoReturnCode = await runCommand('npx', [
+      'auto',
+      'canary',
+      '--force',
+    ])
+    expect(autoReturnCode).toBe(0)
+  }, 40000)
 
-  it("has correct charts uploaded to chartmuseum", async () => {
-    const res = await client.get("charts");
+  it('has correct charts uploaded to chartmuseum', async () => {
+    const res = await client.get('charts')
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(200)
     expect(res.result).toMatchObject({
       common: [
         {
-          name: "common",
-          version: expect.stringContaining("canary"),
+          name: 'common',
+          version: expect.stringContaining('canary'),
         },
       ],
-      "vault-paths": [
+      'vault-paths': [
         {
-          name: "vault-paths",
-          version: expect.stringContaining("canary"),
+          name: 'vault-paths',
+          version: expect.stringContaining('canary'),
         },
       ],
-    });
-  });
-});
+    })
+  })
+})

--- a/test/helm.spec.ts
+++ b/test/helm.spec.ts
@@ -1,9 +1,9 @@
-import { ILogger } from "@auto-it/core";
-import { Helm } from "../src/helm";
-import { rm, mkdir, cp, readdir } from "fs/promises";
-import { Dirent } from "fs";
+import { ILogger } from '@auto-it/core'
+import { Helm } from '../src/helm'
+import { rm, mkdir, cp, readdir } from 'fs/promises'
+import { Dirent } from 'fs'
 
-const exec = jest.fn();
+const exec = jest.fn()
 const logger = jest.fn(() => ({
   log: {
     info: jest.fn(),
@@ -11,225 +11,225 @@ const logger = jest.fn(() => ({
     error: jest.fn(),
     warn: jest.fn(),
   },
-})) as jest.Mock<ILogger>;
+})) as jest.Mock<ILogger>
 
-jest.mock("fs/promises");
+jest.mock('fs/promises')
 
 jest.mock(
-  "@auto-it/core/dist/utils/exec-promise",
+  '@auto-it/core/dist/utils/exec-promise',
   () =>
     (...args: unknown[]) =>
       exec(...args),
-);
+)
 
 describe(Helm.name, () => {
-  let helm: Helm;
+  let helm: Helm
 
   beforeEach(() => {
-    logger.mockClear();
-    exec.mockClear();
-    helm = new Helm(logger(), {});
-  });
+    logger.mockClear()
+    exec.mockClear()
+    helm = new Helm(logger(), {})
+  })
 
-  describe("prepChart", () => {
+  describe('prepChart', () => {
     beforeEach(() => {
-      jest.spyOn(helm, "inlineReplace").mockImplementation(jest.fn());
+      jest.spyOn(helm, 'inlineReplace').mockImplementation(jest.fn())
       jest
-        .spyOn(helm, "findMatchingChartFiles")
-        .mockResolvedValue(["dummyfile"]);
-    });
+        .spyOn(helm, 'findMatchingChartFiles')
+        .mockResolvedValue(['dummyfile'])
+    })
 
-    it("works", async () => {
-      await helm.prepChart("src", "dest", "1234", {
+    it('works', async () => {
+      await helm.prepChart('src', 'dest', '1234', {
         recursive: true,
         replaceFileWithRepository: true,
         replaceVersionToken: true,
-        repository: "testrepo",
-      });
-      expect(exec).toBeCalledWith("helm", ["dep", "up", "src"]);
-      expect(exec).toBeCalledWith("helm", ["package", "src", "-d", "dest"]);
+        repository: 'testrepo',
+      })
+      expect(exec).toBeCalledWith('helm', ['dep', 'up', 'src'])
+      expect(exec).toBeCalledWith('helm', ['package', 'src', '-d', 'dest'])
 
-      expect(rm).toBeCalledWith("src/charts/*.tgz", {
+      expect(rm).toBeCalledWith('src/charts/*.tgz', {
         force: true,
         recursive: true,
-      });
+      })
 
-      expect(helm.inlineReplace).toBeCalledTimes(1);
-    });
+      expect(helm.inlineReplace).toBeCalledTimes(1)
+    })
 
-    it("replaces correct repository", async () => {
-      const replacerFn = jest.fn();
+    it('replaces correct repository', async () => {
+      const replacerFn = jest.fn()
       jest
-        .spyOn(helm, "inlineReplace")
+        .spyOn(helm, 'inlineReplace')
         .mockImplementation(async (path, replacers) => {
           replacerFn(
             replacers(
               `test:  file://../some/path\nkey2:     file://../../otherPath`,
             ),
-          );
-        });
-      await helm.prepChart("src", "dest", "1234", {
+          )
+        })
+      await helm.prepChart('src', 'dest', '1234', {
         recursive: true,
         replaceFileWithRepository: true,
         replaceVersionToken: true,
-        repository: "testrepo",
-      });
-      expect(replacerFn).toBeCalledTimes(1);
+        repository: 'testrepo',
+      })
+      expect(replacerFn).toBeCalledTimes(1)
       expect(replacerFn).toBeCalledWith(
         `test:  'testrepo'\nkey2:     'testrepo'`,
-      );
-    });
+      )
+    })
 
-    it("does not replace repository if disabled", async () => {
-      await helm.prepChart("src", "dest", "1234", {
+    it('does not replace repository if disabled', async () => {
+      await helm.prepChart('src', 'dest', '1234', {
         recursive: true,
         replaceFileWithRepository: false,
         replaceVersionToken: true,
-        repository: "testrepo",
-      });
-      expect(helm.inlineReplace).not.toBeCalled();
-    });
+        repository: 'testrepo',
+      })
+      expect(helm.inlineReplace).not.toBeCalled()
+    })
 
-    it("does not replace repository if repository token not provided", async () => {
-      await helm.prepChart("src", "dest", "1234", {
+    it('does not replace repository if repository token not provided', async () => {
+      await helm.prepChart('src', 'dest', '1234', {
         recursive: true,
         replaceFileWithRepository: true,
         replaceVersionToken: true,
-      });
-      expect(helm.inlineReplace).not.toBeCalled();
-    });
-  });
+      })
+      expect(helm.inlineReplace).not.toBeCalled()
+    })
+  })
 
-  describe("publishCharts", () => {
-    it("works", async () => {
+  describe('publishCharts', () => {
+    it('works', async () => {
       jest
         .mocked(readdir)
         .mockResolvedValueOnce([
-          { name: "someChart.tgz", isFile: () => true } as Dirent,
-        ]);
+          { name: 'someChart.tgz', isFile: () => true } as Dirent,
+        ])
 
-      await helm.publishCharts("path", "repo", true);
+      await helm.publishCharts('path', 'repo', true)
 
-      expect(exec).toBeCalledWith("helm", [
-        "cm-push",
-        "-f",
-        "path/someChart.tgz",
-        "repo",
-      ]);
-    });
+      expect(exec).toBeCalledWith('helm', [
+        'cm-push',
+        '-f',
+        'path/someChart.tgz',
+        'repo',
+      ])
+    })
 
-    it("skips non tgz files and directories", async () => {
+    it('skips non tgz files and directories', async () => {
       jest
         .mocked(readdir)
         .mockResolvedValueOnce([
-          { name: "someFile", isFile: () => true } as Dirent,
-          { name: "someDir", isFile: () => false } as Dirent,
-          { name: "someChart.tgz", isFile: () => true } as Dirent,
-        ]);
+          { name: 'someFile', isFile: () => true } as Dirent,
+          { name: 'someDir', isFile: () => false } as Dirent,
+          { name: 'someChart.tgz', isFile: () => true } as Dirent,
+        ])
 
-      await helm.publishCharts("path", "repo", true);
+      await helm.publishCharts('path', 'repo', true)
 
-      expect(exec).toBeCalledWith("helm", [
-        "cm-push",
-        "-f",
-        "path/someChart.tgz",
-        "repo",
-      ]);
-    });
+      expect(exec).toBeCalledWith('helm', [
+        'cm-push',
+        '-f',
+        'path/someChart.tgz',
+        'repo',
+      ])
+    })
 
-    it("does not publish anything if no charts found", async () => {
-      jest.mocked(readdir).mockResolvedValueOnce([]);
+    it('does not publish anything if no charts found', async () => {
+      jest.mocked(readdir).mockResolvedValueOnce([])
 
-      await helm.publishCharts("path", "repo", true);
+      await helm.publishCharts('path', 'repo', true)
 
-      expect(exec).not.toBeCalled();
-    });
-  });
+      expect(exec).not.toBeCalled()
+    })
+  })
 
-  describe("prepCharts", () => {
+  describe('prepCharts', () => {
     beforeEach(() => {
-      jest.spyOn(helm, "inlineReplace").mockImplementation(jest.fn());
+      jest.spyOn(helm, 'inlineReplace').mockImplementation(jest.fn())
       jest
-        .spyOn(helm, "findMatchingChartFiles")
-        .mockResolvedValue(["dummyfile"]);
-      jest.spyOn(helm, "prepChart").mockImplementation(jest.fn());
-      jest.spyOn(helm, "getChartDirs").mockResolvedValue(["test1", "test2"]);
-    });
+        .spyOn(helm, 'findMatchingChartFiles')
+        .mockResolvedValue(['dummyfile'])
+      jest.spyOn(helm, 'prepChart').mockImplementation(jest.fn())
+      jest.spyOn(helm, 'getChartDirs').mockResolvedValue(['test1', 'test2'])
+    })
 
-    it("works", async () => {
-      await helm.prepCharts("1234", "src", "dest");
+    it('works', async () => {
+      await helm.prepCharts('1234', 'src', 'dest')
 
-      expect(helm.inlineReplace).toHaveBeenCalledTimes(2);
+      expect(helm.inlineReplace).toHaveBeenCalledTimes(2)
       expect(helm.prepChart).toHaveBeenCalledWith(
-        "dest/test1",
-        "dest",
-        "1234",
+        'dest/test1',
+        'dest',
+        '1234',
         {
           recursive: true,
           replaceFileWithRepository: true,
           replaceVersionToken: true,
         },
-      );
+      )
       expect(helm.prepChart).toHaveBeenCalledWith(
-        "dest/test2",
-        "dest",
-        "1234",
+        'dest/test2',
+        'dest',
+        '1234',
         {
           recursive: true,
           replaceFileWithRepository: true,
           replaceVersionToken: true,
         },
-      );
+      )
 
-      expect(rm).toBeCalledWith("dest", { force: true, recursive: true });
-      expect(rm).toBeCalledWith("dest/test1", { force: true, recursive: true });
-      expect(rm).toBeCalledWith("dest/test2", { force: true, recursive: true });
+      expect(rm).toBeCalledWith('dest', { force: true, recursive: true })
+      expect(rm).toBeCalledWith('dest/test1', { force: true, recursive: true })
+      expect(rm).toBeCalledWith('dest/test2', { force: true, recursive: true })
 
-      expect(mkdir).toBeCalledWith("dest", { recursive: true });
-      expect(cp).toBeCalledWith("src", "dest", { recursive: true });
-    });
+      expect(mkdir).toBeCalledWith('dest', { recursive: true })
+      expect(cp).toBeCalledWith('src', 'dest', { recursive: true })
+    })
 
-    it("does not replace version when disabled", async () => {
-      await helm.prepCharts("1234", "src", "dest", {
+    it('does not replace version when disabled', async () => {
+      await helm.prepCharts('1234', 'src', 'dest', {
         replaceVersionToken: false,
-      });
+      })
 
-      expect(helm.inlineReplace).not.toBeCalled();
-    });
+      expect(helm.inlineReplace).not.toBeCalled()
+    })
 
-    it("does not use helm docs when disabled", async () => {
-      helm.options.useHelmDocs = false;
-      await helm.prepCharts("1234", "src", "dest", {});
-      expect(exec).not.toBeCalled();
-    });
+    it('does not use helm docs when disabled', async () => {
+      helm.options.useHelmDocs = false
+      await helm.prepCharts('1234', 'src', 'dest', {})
+      expect(exec).not.toBeCalled()
+    })
 
-    it("uses helm docs when enabled", async () => {
-      helm.options.useHelmDocs = true;
-      await helm.prepCharts("1234", "src", "dest");
-      expect(exec).toBeCalledWith("helm-docs", [
-        "-u",
-        "publish",
-        "-s",
-        "alphanum",
-      ]);
-    });
+    it('uses helm docs when enabled', async () => {
+      helm.options.useHelmDocs = true
+      await helm.prepCharts('1234', 'src', 'dest')
+      expect(exec).toBeCalledWith('helm-docs', [
+        '-u',
+        'publish',
+        '-s',
+        'alphanum',
+      ])
+    })
 
-    it("replaces correct version", async () => {
-      const replacerFn = jest.fn();
+    it('replaces correct version', async () => {
+      const replacerFn = jest.fn()
       jest
-        .spyOn(helm, "inlineReplace")
+        .spyOn(helm, 'inlineReplace')
         .mockImplementation(async (path, replacers) => {
           replacerFn(
             replacers(
               `${helm.options.versionToken.toLowerCase()}\ntest\n${helm.options.versionToken.toUpperCase()}`,
             ),
-          );
-        });
-      await helm.prepCharts("1234", "src", "dest");
-      expect(replacerFn).toBeCalledTimes(2);
-      expect(replacerFn).toBeCalledWith(`1234\ntest\n1234`);
-      expect(replacerFn).toBeCalledWith(`1234\ntest\n1234`);
+          )
+        })
+      await helm.prepCharts('1234', 'src', 'dest')
+      expect(replacerFn).toBeCalledTimes(2)
+      expect(replacerFn).toBeCalledWith(`1234\ntest\n1234`)
+      expect(replacerFn).toBeCalledWith(`1234\ntest\n1234`)
       //expect(helm.inlineReplace).toBeCalledWith(8)
-    });
-  });
-});
+    })
+  })
+})

--- a/test/helm.spec.ts
+++ b/test/helm.spec.ts
@@ -187,6 +187,7 @@ describe(Helm.name, () => {
 
       expect(mkdir).toBeCalledWith('dest', { recursive: true })
       expect(cp).toBeCalledWith('src', 'dest', { recursive: true })
+      expect(helm.getChartDirs).toBeCalledWith('dest', true)
     })
 
     it('does not replace version when disabled', async () => {
@@ -230,6 +231,44 @@ describe(Helm.name, () => {
       expect(replacerFn).toBeCalledWith(`1234\ntest\n1234`)
       expect(replacerFn).toBeCalledWith(`1234\ntest\n1234`)
       //expect(helm.inlineReplace).toBeCalledWith(8)
+    })
+  })
+
+  describe('getChartDirs', () => {
+
+    it('works for recursive', async () => {
+      //await helm.prepCharts('1234', 'src', 'dest')
+      jest.mocked(readdir).mockResolvedValue(
+        [
+          {
+            isDirectory: () => true,
+            name: 'dummy1'
+          },
+          {
+            isDirectory: () => true,
+            name: 'dummy2'
+          }
+        ] as jest.MockedObjectDeep<Dirent[]>)
+      const res = await helm.getChartDirs('dummy', true)
+
+      expect(res).toMatchObject(expect.arrayContaining(['dummy1','dummy2']))
+    })
+
+    it('works for nonrecursive', async () => {
+      jest.mocked(readdir).mockResolvedValue(
+        [
+          {
+            isDirectory: () => true,
+            name: 'dummy1'
+          },
+          {
+            isDirectory: () => true,
+            name: 'dummy2'
+          }
+        ] as jest.MockedObjectDeep<Dirent[]>)
+      const res = await helm.getChartDirs('dummy', false)
+
+      expect(res).toMatchObject(['dummy'])
     })
   })
 })

--- a/test/helm.spec.ts
+++ b/test/helm.spec.ts
@@ -235,8 +235,11 @@ describe(Helm.name, () => {
   })
 
   describe('getChartDirs', () => {
+    beforeEach(() => {
+      jest.mocked(readdir).mockReset()
+    })
+
     it('works for recursive', async () => {
-      //await helm.prepCharts('1234', 'src', 'dest')
       jest.mocked(readdir).mockResolvedValue([
         {
           isDirectory: () => true,
@@ -249,6 +252,8 @@ describe(Helm.name, () => {
       ] as jest.MockedObjectDeep<Dirent[]>)
       const res = await helm.getChartDirs('dummy', true)
 
+      expect(readdir).toBeCalledTimes(1)
+      expect(readdir).toBeCalledWith('dummy', {recursive: false, withFileTypes: true})
       expect(res).toMatchObject(expect.arrayContaining(['dummy1', 'dummy2']))
     })
 
@@ -264,7 +269,7 @@ describe(Helm.name, () => {
         },
       ] as jest.MockedObjectDeep<Dirent[]>)
       const res = await helm.getChartDirs('dummy', false)
-
+      expect(readdir).not.toBeCalled()
       expect(res).toMatchObject(['dummy'])
     })
   })

--- a/test/helm.spec.ts
+++ b/test/helm.spec.ts
@@ -253,7 +253,10 @@ describe(Helm.name, () => {
       const res = await helm.getChartDirs('dummy', true)
 
       expect(readdir).toBeCalledTimes(1)
-      expect(readdir).toBeCalledWith('dummy', {recursive: false, withFileTypes: true})
+      expect(readdir).toBeCalledWith('dummy', {
+        recursive: false,
+        withFileTypes: true,
+      })
       expect(res).toMatchObject(expect.arrayContaining(['dummy1', 'dummy2']))
     })
 

--- a/test/helm.spec.ts
+++ b/test/helm.spec.ts
@@ -235,37 +235,34 @@ describe(Helm.name, () => {
   })
 
   describe('getChartDirs', () => {
-
     it('works for recursive', async () => {
       //await helm.prepCharts('1234', 'src', 'dest')
-      jest.mocked(readdir).mockResolvedValue(
-        [
-          {
-            isDirectory: () => true,
-            name: 'dummy1'
-          },
-          {
-            isDirectory: () => true,
-            name: 'dummy2'
-          }
-        ] as jest.MockedObjectDeep<Dirent[]>)
+      jest.mocked(readdir).mockResolvedValue([
+        {
+          isDirectory: () => true,
+          name: 'dummy1',
+        },
+        {
+          isDirectory: () => true,
+          name: 'dummy2',
+        },
+      ] as jest.MockedObjectDeep<Dirent[]>)
       const res = await helm.getChartDirs('dummy', true)
 
-      expect(res).toMatchObject(expect.arrayContaining(['dummy1','dummy2']))
+      expect(res).toMatchObject(expect.arrayContaining(['dummy1', 'dummy2']))
     })
 
     it('works for nonrecursive', async () => {
-      jest.mocked(readdir).mockResolvedValue(
-        [
-          {
-            isDirectory: () => true,
-            name: 'dummy1'
-          },
-          {
-            isDirectory: () => true,
-            name: 'dummy2'
-          }
-        ] as jest.MockedObjectDeep<Dirent[]>)
+      jest.mocked(readdir).mockResolvedValue([
+        {
+          isDirectory: () => true,
+          name: 'dummy1',
+        },
+        {
+          isDirectory: () => true,
+          name: 'dummy2',
+        },
+      ] as jest.MockedObjectDeep<Dirent[]>)
       const res = await helm.getChartDirs('dummy', false)
 
       expect(res).toMatchObject(['dummy'])

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,367 +1,367 @@
-import * as Auto from "@auto-it/core";
-import { makeHooks } from "@auto-it/core/dist/utils/make-hooks";
-import { dummyLog } from "@auto-it/core/dist/utils/logger";
-import { Helm } from "../src/helm";
-import HelmPlugin, { IHelmPluginOptions } from "../src";
-import Git from "@auto-it/core/dist/git";
+import * as Auto from '@auto-it/core'
+import { makeHooks } from '@auto-it/core/dist/utils/make-hooks'
+import { dummyLog } from '@auto-it/core/dist/utils/logger'
+import { Helm } from '../src/helm'
+import HelmPlugin, { IHelmPluginOptions } from '../src'
+import Git from '@auto-it/core/dist/git'
 
-const exec = jest.fn();
+const exec = jest.fn()
 
-jest.mock("@auto-it/core/dist/utils/get-current-branch", () => ({
-  getCurrentBranch: () => "next",
-}));
+jest.mock('@auto-it/core/dist/utils/get-current-branch', () => ({
+  getCurrentBranch: () => 'next',
+}))
 
 jest.mock(
-  "@auto-it/core/dist/utils/exec-promise",
+  '@auto-it/core/dist/utils/exec-promise',
   () =>
     (...args: unknown[]) =>
       exec(...args),
-);
+)
 
-jest.mock("../src/helm");
-const helmMocked = jest.mocked(Helm);
+jest.mock('../src/helm')
+const helmMocked = jest.mocked(Helm)
 
 const setup = (
   mockGit?: Partial<Git>,
   options?: IHelmPluginOptions,
   checkEnv?: jest.SpyInstance,
-  prereleaseBranches: string[] = ["next"],
+  prereleaseBranches: string[] = ['next'],
 ) => {
-  const plugin = new HelmPlugin(options || {});
-  const hooks = makeHooks();
+  const plugin = new HelmPlugin(options || {})
+  const hooks = makeHooks()
 
   plugin.apply({
     checkEnv,
     hooks,
     git: mockGit,
-    remote: "origin",
+    remote: 'origin',
     logger: dummyLog(),
     prefixRelease: (r: string) => r,
     config: { prereleaseBranches },
-    getCurrentVersion: () => "v1.0.0",
-  } as unknown as Auto.Auto);
+    getCurrentVersion: () => 'v1.0.0',
+  } as unknown as Auto.Auto)
 
-  return hooks;
-};
+  return hooks
+}
 
 describe(HelmPlugin.name, () => {
   beforeEach(() => {
-    helmMocked.mockClear();
-    exec.mockClear();
-  });
+    helmMocked.mockClear()
+    exec.mockClear()
+  })
 
-  describe("validateConfig", () => {
-    it("should error without options", async () => {
-      const hooks = setup();
+  describe('validateConfig', () => {
+    it('should error without options', async () => {
+      const hooks = setup()
       await expect(
-        hooks.validateConfig.promise("helm", null),
-      ).resolves.toHaveLength(1);
-    });
-  });
+        hooks.validateConfig.promise('helm', null),
+      ).resolves.toHaveLength(1)
+    })
+  })
 
-  describe("version", () => {
+  describe('version', () => {
     // do nothing without git
-    it("fails without git", async () => {
-      const hooks = setup();
-      await hooks.version.promise({ bump: Auto.SEMVER.patch });
-    });
+    it('fails without git', async () => {
+      const hooks = setup()
+      await hooks.version.promise({ bump: Auto.SEMVER.patch })
+    })
 
     // do nothing with bad bump
-    it("fails with a invalid bump type", async () => {
-      const hooks = setup({});
-      await hooks.version.promise({ bump: "wrong" as Auto.SEMVER });
-    });
+    it('fails with a invalid bump type', async () => {
+      const hooks = setup({})
+      await hooks.version.promise({ bump: 'wrong' as Auto.SEMVER })
+    })
 
-    it("correctly labels valid bump", async () => {
-      const hooks = setup({});
-      await hooks.version.promise({ bump: Auto.SEMVER.patch });
-    });
-  });
+    it('correctly labels valid bump', async () => {
+      const hooks = setup({})
+      await hooks.version.promise({ bump: Auto.SEMVER.patch })
+    })
+  })
 
-  describe("next", () => {
-    it("preps charts with correct version and repository", async () => {
+  describe('next', () => {
+    it('preps charts with correct version and repository', async () => {
       const hooks = setup(
         {
-          getLastTagNotInBaseBranch: async () => "0.0.1",
-          getLatestRelease: async () => "0.0.1",
+          getLastTagNotInBaseBranch: async () => '0.0.1',
+          getLatestRelease: async () => '0.0.1',
         },
-        { enablePreleases: true, repository: "dummy", push: true },
-      );
-      const res = await hooks.next.promise(["0.0.1"], {
+        { enablePreleases: true, repository: 'dummy', push: true },
+      )
+      const res = await hooks.next.promise(['0.0.1'], {
         bump: Auto.SEMVER.patch,
-      } as never);
-      const helm = helmMocked.mock.instances[0];
+      } as never)
+      const helm = helmMocked.mock.instances[0]
 
       expect(helm.prepCharts).toBeCalledWith(
-        "0.0.2-next.0",
-        ".",
-        "publish",
+        '0.0.2-next.0',
+        '.',
+        'publish',
         expect.objectContaining({
           recursive: false,
           replaceFileWithRepository: false,
           replaceVersionToken: true,
-          repository: "dummy",
+          repository: 'dummy',
         }),
-      );
-      expect(helm.publishCharts).toBeCalledWith("publish", "", false);
+      )
+      expect(helm.publishCharts).toBeCalledWith('publish', '', false)
 
-      expect(exec).toBeCalledTimes(2);
-      expect(exec).toBeCalledWith("git", [
-        "tag",
-        "0.0.2-next.0",
-        "-m",
+      expect(exec).toBeCalledTimes(2)
+      expect(exec).toBeCalledWith('git', [
+        'tag',
+        '0.0.2-next.0',
+        '-m',
         '"Tag pre-release: 0.0.2-next.0"',
-      ]);
-      expect(exec).toBeCalledWith("git", ["push", "origin", "next", "--tags"]);
+      ])
+      expect(exec).toBeCalledWith('git', ['push', 'origin', 'next', '--tags'])
 
       expect(res).toMatchObject(
-        expect.arrayContaining(["0.0.1", "0.0.2-next.0"]),
-      );
-    });
+        expect.arrayContaining(['0.0.1', '0.0.2-next.0']),
+      )
+    })
 
-    it("does not publish if push disabled", async () => {
+    it('does not publish if push disabled', async () => {
       const hooks = setup(
         {
-          getLastTagNotInBaseBranch: async () => "0.0.1",
-          getLatestRelease: async () => "0.0.1",
+          getLastTagNotInBaseBranch: async () => '0.0.1',
+          getLatestRelease: async () => '0.0.1',
         },
         { enablePreleases: true, push: false },
-      );
-      await hooks.next.promise(["0.0.1"], {
+      )
+      await hooks.next.promise(['0.0.1'], {
         bump: Auto.SEMVER.patch,
-      } as never);
-      const helm = helmMocked.mock.instances[0];
+      } as never)
+      const helm = helmMocked.mock.instances[0]
 
-      expect(helm.publishCharts).not.toBeCalled();
-    });
+      expect(helm.publishCharts).not.toBeCalled()
+    })
 
-    it("returns default version if git not found", async () => {
-      const hooks = setup();
-      const res = await hooks.next.promise(["1234"], {} as never);
-      expect(res).toMatchObject(expect.arrayContaining(["1234"]));
-    });
+    it('returns default version if git not found', async () => {
+      const hooks = setup()
+      const res = await hooks.next.promise(['1234'], {} as never)
+      expect(res).toMatchObject(expect.arrayContaining(['1234']))
+    })
 
-    it("fails with bad version", async () => {
+    it('fails with bad version', async () => {
       const hooks = setup(
         {
-          getLastTagNotInBaseBranch: async () => "invalid",
-          getLatestRelease: async () => "invalid",
+          getLastTagNotInBaseBranch: async () => 'invalid',
+          getLatestRelease: async () => 'invalid',
         },
         { enablePreleases: true },
-      );
-      const res = await hooks.next.promise(["invalid"], {
-        bump: "wrong",
-      } as never);
+      )
+      const res = await hooks.next.promise(['invalid'], {
+        bump: 'wrong',
+      } as never)
       expect(res).toMatchObject(
-        expect.arrayContaining(["invalid", "prerelease"]),
-      );
-    });
+        expect.arrayContaining(['invalid', 'prerelease']),
+      )
+    })
 
-    it("skips if prereleases disabled", async () => {
-      const hooks = setup({}, { enablePreleases: false });
-      await hooks.next.promise(["1234"], { bump: Auto.SEMVER.patch } as never);
-      const helm = helmMocked.mock.instances[0];
-      expect(helm.prepCharts).not.toBeCalled();
-      expect(helm.publishCharts).not.toBeCalled();
-      expect(exec).not.toBeCalled();
-    });
-  });
+    it('skips if prereleases disabled', async () => {
+      const hooks = setup({}, { enablePreleases: false })
+      await hooks.next.promise(['1234'], { bump: Auto.SEMVER.patch } as never)
+      const helm = helmMocked.mock.instances[0]
+      expect(helm.prepCharts).not.toBeCalled()
+      expect(helm.publishCharts).not.toBeCalled()
+      expect(exec).not.toBeCalled()
+    })
+  })
 
-  describe("publish", () => {
-    it("fails without git", async () => {
-      const hooks = setup();
-      await hooks.publish.promise({} as never);
-    });
+  describe('publish', () => {
+    it('fails without git', async () => {
+      const hooks = setup()
+      await hooks.publish.promise({} as never)
+    })
 
-    it("fails with invalid version", async () => {
-      const hooks = setup({ getLatestTagInBranch: async () => "wrong" });
-      await hooks.publish.promise({ bump: Auto.SEMVER.patch });
-      const helm = helmMocked.mock.instances[0];
+    it('fails with invalid version', async () => {
+      const hooks = setup({ getLatestTagInBranch: async () => 'wrong' })
+      await hooks.publish.promise({ bump: Auto.SEMVER.patch })
+      const helm = helmMocked.mock.instances[0]
 
-      expect(helm.prepCharts).not.toBeCalled();
-      expect(helm.publishCharts).not.toBeCalled();
-    });
+      expect(helm.prepCharts).not.toBeCalled()
+      expect(helm.publishCharts).not.toBeCalled()
+    })
 
-    it("fails with invalid bump", async () => {
-      const hooks = setup({ getLatestTagInBranch: async () => "0.0.1" });
-      await hooks.publish.promise({ bump: "wrong" } as never);
-      const helm = helmMocked.mock.instances[0];
+    it('fails with invalid bump', async () => {
+      const hooks = setup({ getLatestTagInBranch: async () => '0.0.1' })
+      await hooks.publish.promise({ bump: 'wrong' } as never)
+      const helm = helmMocked.mock.instances[0]
 
-      expect(helm.prepCharts).not.toBeCalled();
-      expect(helm.publishCharts).not.toBeCalled();
-    });
+      expect(helm.prepCharts).not.toBeCalled()
+      expect(helm.publishCharts).not.toBeCalled()
+    })
 
-    it("skips if publishing not enabled", async () => {
+    it('skips if publishing not enabled', async () => {
       const hooks = setup(
-        { getLatestTagInBranch: async () => "0.0.1" },
-        { repository: "dummy", push: false },
-      );
-      await hooks.publish.promise({ bump: Auto.SEMVER.patch });
+        { getLatestTagInBranch: async () => '0.0.1' },
+        { repository: 'dummy', push: false },
+      )
+      await hooks.publish.promise({ bump: Auto.SEMVER.patch })
 
-      const helm = helmMocked.mock.instances[0];
+      const helm = helmMocked.mock.instances[0]
 
       expect(helm.prepCharts).toBeCalledWith(
-        "0.0.2",
-        ".",
-        "publish",
+        '0.0.2',
+        '.',
+        'publish',
         expect.objectContaining({
           recursive: false,
           replaceFileWithRepository: false,
           replaceVersionToken: true,
-          repository: "dummy",
+          repository: 'dummy',
         }),
-      );
-      expect(helm.publishCharts).not.toBeCalled();
-      expect(exec).not.toBeCalled();
-    });
+      )
+      expect(helm.publishCharts).not.toBeCalled()
+      expect(exec).not.toBeCalled()
+    })
 
-    it("preps chart with correct version and repository", async () => {
+    it('preps chart with correct version and repository', async () => {
       const hooks = setup(
-        { getLatestTagInBranch: async () => "0.0.1" },
-        { repository: "dummy", push: true },
-      );
-      await hooks.publish.promise({ bump: Auto.SEMVER.patch });
+        { getLatestTagInBranch: async () => '0.0.1' },
+        { repository: 'dummy', push: true },
+      )
+      await hooks.publish.promise({ bump: Auto.SEMVER.patch })
 
-      const helm = helmMocked.mock.instances[0];
+      const helm = helmMocked.mock.instances[0]
 
       expect(helm.prepCharts).toBeCalledWith(
-        "0.0.2",
-        ".",
-        "publish",
+        '0.0.2',
+        '.',
+        'publish',
         expect.objectContaining({
           recursive: false,
           replaceFileWithRepository: false,
           replaceVersionToken: true,
-          repository: "dummy",
+          repository: 'dummy',
         }),
-      );
-      expect(helm.publishCharts).toBeCalledWith("publish", "", false);
+      )
+      expect(helm.publishCharts).toBeCalledWith('publish', '', false)
 
-      expect(exec).toBeCalledTimes(2);
-      expect(exec).toBeCalledWith("git", [
-        "tag",
-        "0.0.2",
-        "-m",
+      expect(exec).toBeCalledTimes(2)
+      expect(exec).toBeCalledWith('git', [
+        'tag',
+        '0.0.2',
+        '-m',
         '"Update version to 0.0.2"',
-      ]);
-      expect(exec).toBeCalledWith("git", [
-        "push",
-        "--follow-tags",
-        "--set-upstream",
-        "origin",
-        "next",
-      ]);
-    });
-  });
+      ])
+      expect(exec).toBeCalledWith('git', [
+        'push',
+        '--follow-tags',
+        '--set-upstream',
+        'origin',
+        'next',
+      ])
+    })
+  })
 
-  describe("beforeRun", () => {
-    it("validates dependencies", async () => {
-      const hooks = setup({});
-      await hooks.beforeRun.promise({} as never);
+  describe('beforeRun', () => {
+    it('validates dependencies', async () => {
+      const hooks = setup({})
+      await hooks.beforeRun.promise({} as never)
 
-      const helm = helmMocked.mock.instances[0];
+      const helm = helmMocked.mock.instances[0]
 
-      expect(helm.validateDependencies).toBeCalledTimes(1);
-    });
-  });
+      expect(helm.validateDependencies).toBeCalledTimes(1)
+    })
+  })
 
-  describe("getPreviousVersion", () => {
-    it("returns previous version", async () => {
-      const hooks = setup({ getLatestTagInBranch: async () => "1.2.3" });
-      const res = await hooks.getPreviousVersion.promise();
-      expect(res).toBe("1.2.3");
-    });
+  describe('getPreviousVersion', () => {
+    it('returns previous version', async () => {
+      const hooks = setup({ getLatestTagInBranch: async () => '1.2.3' })
+      const res = await hooks.getPreviousVersion.promise()
+      expect(res).toBe('1.2.3')
+    })
 
-    it("fails without git", async () => {
-      const hooks = setup();
-      await expect(hooks.getPreviousVersion.promise()).rejects.toThrow();
-    });
-  });
+    it('fails without git', async () => {
+      const hooks = setup()
+      await expect(hooks.getPreviousVersion.promise()).rejects.toThrow()
+    })
+  })
 
-  describe("canary", () => {
-    it("fails without git", async () => {
-      const hooks = setup();
-      await hooks.canary.promise({} as never);
-    });
+  describe('canary', () => {
+    it('fails without git', async () => {
+      const hooks = setup()
+      await hooks.canary.promise({} as never)
+    })
 
-    it("fails with invalid version bump", async () => {
+    it('fails with invalid version bump', async () => {
       const hooks = setup(
-        { getLatestRelease: async () => "0.0.1" },
+        { getLatestRelease: async () => '0.0.1' },
         { enableCanary: true },
-      );
+      )
       await hooks.canary.promise({
-        bump: "wrong",
-        canaryIdentifier: "canary",
-      } as never);
-      const helm = helmMocked.mock.instances[0];
-      expect(helm.prepCharts).not.toBeCalled();
-      expect(helm.publishCharts).not.toBeCalled();
-    });
+        bump: 'wrong',
+        canaryIdentifier: 'canary',
+      } as never)
+      const helm = helmMocked.mock.instances[0]
+      expect(helm.prepCharts).not.toBeCalled()
+      expect(helm.publishCharts).not.toBeCalled()
+    })
 
-    it("skips is canary disabled", async () => {
+    it('skips is canary disabled', async () => {
       const hooks = setup(
-        { getLatestRelease: async () => "0.0.1" },
+        { getLatestRelease: async () => '0.0.1' },
         { enableCanary: false },
-      );
+      )
       await hooks.canary.promise({
-        bump: "wrong",
-        canaryIdentifier: "canary",
-      } as never);
-      const helm = helmMocked.mock.instances[0];
-      expect(helm.prepCharts).not.toBeCalled();
-      expect(helm.publishCharts).not.toBeCalled();
-    });
+        bump: 'wrong',
+        canaryIdentifier: 'canary',
+      } as never)
+      const helm = helmMocked.mock.instances[0]
+      expect(helm.prepCharts).not.toBeCalled()
+      expect(helm.publishCharts).not.toBeCalled()
+    })
 
-    it("skips is dryrun mode", async () => {
+    it('skips is dryrun mode', async () => {
       const hooks = setup(
-        { getLatestRelease: async () => "0.0.1" },
+        { getLatestRelease: async () => '0.0.1' },
         { enableCanary: true },
-      );
+      )
       await hooks.canary.promise({
         bump: Auto.SEMVER.patch as never,
-        canaryIdentifier: "canary",
+        canaryIdentifier: 'canary',
         dryRun: true,
-      });
-      const helm = helmMocked.mock.instances[0];
-      expect(helm.prepCharts).not.toBeCalled();
-      expect(helm.publishCharts).not.toBeCalled();
-    });
+      })
+      const helm = helmMocked.mock.instances[0]
+      expect(helm.prepCharts).not.toBeCalled()
+      expect(helm.publishCharts).not.toBeCalled()
+    })
 
-    it("skips publishing if push not enabled", async () => {
+    it('skips publishing if push not enabled', async () => {
       const hooks = setup(
-        { getLatestRelease: async () => "0.0.1" },
+        { getLatestRelease: async () => '0.0.1' },
         { enableCanary: true, push: false },
-      );
+      )
       await hooks.canary.promise({
         bump: Auto.SEMVER.patch,
-        canaryIdentifier: "canary",
-      } as never);
-      const helm = helmMocked.mock.instances[0];
-      expect(helm.publishCharts).not.toBeCalled();
-    });
+        canaryIdentifier: 'canary',
+      } as never)
+      const helm = helmMocked.mock.instances[0]
+      expect(helm.publishCharts).not.toBeCalled()
+    })
 
-    it("preps chart with correct version and repository", async () => {
+    it('preps chart with correct version and repository', async () => {
       const hooks = setup(
-        { getLatestRelease: async () => "0.0.1" },
-        { enableCanary: true, repository: "dummy", push: true },
-      );
+        { getLatestRelease: async () => '0.0.1' },
+        { enableCanary: true, repository: 'dummy', push: true },
+      )
       await hooks.canary.promise({
         bump: Auto.SEMVER.patch,
-        canaryIdentifier: "canary",
-      } as never);
-      const helm = helmMocked.mock.instances[0];
+        canaryIdentifier: 'canary',
+      } as never)
+      const helm = helmMocked.mock.instances[0]
       expect(helm.prepCharts).toBeCalledWith(
-        "1.0.1-canary",
-        ".",
-        "publish",
+        '1.0.1-canary',
+        '.',
+        'publish',
         expect.objectContaining({
           recursive: false,
           replaceFileWithRepository: false,
           replaceVersionToken: true,
-          repository: "dummy",
+          repository: 'dummy',
         }),
-      );
-      expect(helm.publishCharts).toBeCalledWith("publish", "", false);
-    });
-  });
-});
+      )
+      expect(helm.publishCharts).toBeCalledWith('publish', '', false)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #65 #104

## differing `readdir` behavior
It appears that the `recursive` param of `readdir` differs between local development (mac in my case) and github actions

Local (mac)
```
$ mkdir -p test1/d0/d1
$ node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: true}).then((res) => console.log(res))"
[ 'd0' ]
```

GitHub actions:
```
$ mkdir -p test1/d0/d1
$ node -e "const readdir = require('fs/promises').readdir; readdir('test1',{recursive: true}).then((res) => console.log(res))"
[ 'd0', 'd0/d1' ]
```

Possibly related to?
- https://github.com/nodejs/node/issues/48858
- https://github.com/nodejs/node/issues/49243

When used without the `recursive` option `readdir` will only read directories from the top level in both environments.

## Incorrect `getChartDirs` result for nonrecursive config
When `recursive` set to `false` the returned value of `getChartDirs` was a string instead of an array. This caused subsequent iteration to be against a string instead of array

## No such file for `destPath`
Iterating over charts was being done against `srcPath` instead of `destPath`. This resulted in a cryptic seeming error message like this:
```
[Error: ENOENT: no such file or directory, scandir 'publish/templates'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'scandir',
  path: 'publish/templates'
}
```

The code in this package was doing something that amounted to this:
```
cp -r myChartPath myDestPath
ls -l myDestPath/myChartPath
```

In the above case, there would be no `myChartPath` under `myDestPath`, only the contents of `myChartPath`
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.1.4-next.1`

<details>
  <summary>Changelog</summary>

  :tada: This release contains work from a new contributor! :tada:
  
  Thank you, Rohit Khattar ([@rfun](https://github.com/rfun)), for all your work!
  
  #### 🐛 Bug Fix
  
  - Publish directory and recursive settings unexpected behavior [#105](https://github.com/ejhayes/auto-plugin-helm-chartmuseum/pull/105) ([@rfun](https://github.com/rfun) [@ejhayes](https://github.com/ejhayes))
  - Fix reading recurive dirs [#65](https://github.com/ejhayes/auto-plugin-helm-chartmuseum/pull/65) ([@rfun](https://github.com/rfun))
  
  #### 🔩 Dependency Updates
  
  - Bump actions/checkout from 3 to 4 [#72](https://github.com/ejhayes/auto-plugin-helm-chartmuseum/pull/72) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 3
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Eric Hayes ([@ejhayes](https://github.com/ejhayes))
  - Rohit Khattar ([@rfun](https://github.com/rfun))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
